### PR TITLE
fix: Update default command-coverage-options to remove specific coverage filter.

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -15,7 +15,7 @@ on:
         type: string
       command-coverage-options:
         description: Options for the infection tool when generating coverage.
-        default: --only-covered
+        default:
         required: false
         type: string
       command-options:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
