### PR TITLE
fix(deps): Upgrade codecov action from `v4` to `v5` for improved functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## v1.0.2 Under development
+## v1.0.2 August 27, 2025
+
+- Bug #52: Upgrade codecov action from `v4` to `v5` for improved functionality (@terabytesoftw)
 
 ## v1.0.1 August 17, 2025
 

--- a/actions/phpunit/action.yml
+++ b/actions/phpunit/action.yml
@@ -116,7 +116,7 @@ runs:
 
     - name: Upload coverage to Codecov.
       if: inputs.coverage-driver != '' && inputs.coverage-driver != 'none' && inputs.coverage-token != ''
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ inputs.coverage-token }}
         file: ./${{ inputs.coverage-file }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v1.0.2 changelog header to “August 27, 2025” and added an entry noting the Codecov action upgrade; minor formatting adjustment.

* **Chores**
  * Upgraded Codecov integration to v5 to improve reliability of coverage uploads and align with latest tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->