### PR TITLE
fix: Update default operating systems to use 'windows-2022' across workflows and documentation.

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -38,9 +38,14 @@ on:
         default:
         required: false
         type: string
+      hook:
+        description: Hook to run.
+        default:
+        required: false
+        type: string
       os:
         description: Operating systems to test, separated by comma.
-        default: '["ubuntu-latest","windows-latest"]'
+        default: '["ubuntu-latest","windows-2022"]'
         required: false
         type: string
       php-ini-values:
@@ -102,6 +107,11 @@ jobs:
           ini-values: ${{ inputs.php-ini-values }}
           php-version: ${{ matrix.php-version }}
           tools: ${{ inputs.tools }}
+
+      - name: Run hook.
+        if: inputs.hook != ''
+        run: ${{ inputs.hook }}
+        shell: bash
 
       - name: Generate base classes for all suites.
         run: vendor/bin/codecept build

--- a/.github/workflows/phpunit-database.yml
+++ b/.github/workflows/phpunit-database.yml
@@ -81,7 +81,7 @@ on:
         type: string
       os:
         description: Operating systems to test, separated by comma.
-        default: '["ubuntu-latest","windows-latest"]'
+        default: '["ubuntu-latest","windows-2022"]'
         required: false
         type: string
       phpunit-configuration:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,11 +3,6 @@ name: phpunit
 on:
   workflow_call:
     inputs:
-      before-hook:
-        description: Before hook to run.
-        default:
-        required: false
-        type: string
       composer-command:
         description: Composer command to run.
         default: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
@@ -48,9 +43,14 @@ on:
         default:
         required: false
         type: string
+      hook:
+        description: Hook to run.
+        default:
+        required: false
+        type: string
       os:
         description: Operating systems to test, separated by comma.
-        default: '["ubuntu-latest","windows-latest"]'
+        default: '["ubuntu-latest","windows-2022"]'
         required: false
         type: string
       phpunit-configuration:
@@ -139,9 +139,10 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: ${{ inputs.tools }}
 
-      - name: Run before hook.
-        if: inputs.before-hook != ''
-        run: ${{ inputs.before-hook }}
+      - name: Run hook.
+        if: inputs.hook != ''
+        run: ${{ inputs.hook }}
+        shell: bash
 
       - name: Run PHPUnit tests with coverage.
         uses: php-forge/actions/actions/phpunit@main

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ jobs:
       ini-values: date.timezone='UTC', memory_limit=-1
 
       # Operating systems
-      os: '["ubuntu-latest", "windows-latest"]'
+      os: '["ubuntu-latest", "windows-2022"]'
 
       # PHP versions to test
       php-version: '["8.1", "8.2", "8.3", "8.4"]'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional hook input to PHPUnit and Codeception workflows to run a custom command; replaces before-hook in PHPUnit.

- Chores
  - Updated default Windows runner from windows-latest to windows-2022 across relevant workflows.

- Documentation
  - Updated README examples to use windows-2022 in OS matrices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->