### PR TITLE
fix(workflow): Better naming workflow `linter.yml` to `reusable-linter.yml`.

### DIFF
--- a/.github/workflows/reusable-linter.yml
+++ b/.github/workflows/reusable-linter.yml
@@ -19,11 +19,6 @@ on:
         default: true
         required: false
         type: boolean
-      linter-version:
-        description: Super linter version.
-        default: v8.1.0
-        required: false
-        type: string
       os:
         description: OS runner as a JSON array string '["ubuntu-latest"]'.
         default: '["ubuntu-latest"]'
@@ -31,24 +26,24 @@ on:
         type: string
 
     secrets:
-      GITHUB_TOKEN:
-        description: GitHub token for Super Linter.
+      AUTH_TOKEN:
+        description: GitHub token.
         required: true
 
 jobs:
   lint:
-    name: Super Linter
-
     concurrency:
       cancel-in-progress: ${{ inputs.enable-concurrency }}
       group: ${{ inputs.concurrency-group }}
 
-    runs-on: ${{ fromJSON(inputs.os) }}
+    name: Super Linter
 
     permissions:
       checks: write
       contents: read
       statuses: write
+
+    runs-on: ${{ fromJSON(inputs.os) }}
 
     steps:
       - name: Checkout.
@@ -57,9 +52,9 @@ jobs:
           fetch-depth: ${{ inputs.checkout_fetch_depth }}
 
       - name: Run super linter.
-        uses: super-linter/super-linter/slim-${{ inputs.linter-version }}
+        uses: super-linter/super-linter/slim@v8.1.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
           VALIDATE_CHECKOV: ${{ env.VALIDATE_CHECKOV || 'false' }}
           VALIDATE_ENV: ${{ env.VALIDATE_ENV || 'false' }}
           VALIDATE_GIT_MERGE_CONFLICT_MARKERS: >-


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
