### PR TITLE
fix(linter): Better naming `reusable-linter.yml` to `super-linter.yml`.

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -31,7 +31,7 @@ on:
         required: true
 
 jobs:
-  lint:
+  linter:
     concurrency:
       cancel-in-progress: ${{ inputs.enable-concurrency }}
       group: ${{ inputs.concurrency-group }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.0.0 Under development
 
 - Enh #55: Add Super Linter reusable workflow for code quality checks (@terabytesoftw)
+- Fix #58: Better naming `reusable-linter.yml` to `super-linter.yml` (@terabytesoftw)
 
 ## v1.0.4 August 30, 2025
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.
- Chores
  - Renamed the CI linter job for clearer naming.
  - Standardized the reusable workflow name to “super-linter.”
- Documentation
  - Updated the changelog to reflect the workflow rename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->