### PR TITLE
fix(linter): Add permissions to linter job in `linter.yml` and `super-linter.yml`.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,5 +8,9 @@ name: linter
 jobs:
   linter:
     uses: php-forge/actions/.github/workflows/super-linter.yml@main
+    permissions:
+      checks: write
+      contents: read
+      statuses: write
     secrets:
       AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -38,11 +38,6 @@ jobs:
 
     name: Super Linter
 
-    permissions:
-      checks: write
-      contents: read
-      statuses: write
-
     runs-on: ${{ fromJSON(inputs.os) }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Enh #55: Add Super Linter reusable workflow for code quality checks (@terabytesoftw)
 - Bug #56: Add `linter.yml` workflow configuration for pull requests and pushes (@terabytesoftw)
 - Bug #57: Better naming workflow `linter.yml` to `reusable-linter.yml` (@terabytesoftw)
-- Fix #58: Better naming workflow `reusable-linter.yml` to `super-linter.yml` (@terabytesoftw)
+- Bug #58: Better naming workflow `reusable-linter.yml` to `super-linter.yml` (@terabytesoftw)
+- Bug #59: Add permissions to `linter` job in `linter.yml` and `super-linter.yml` (@terabytesoftw)
 
 ## v1.0.4 August 30, 2025
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ name: linter
 jobs:
   linter:
     uses: php-forge/actions/.github/workflows/super-linter.yml@main
+    permissions:
+      checks: write
+      contents: read
+      statuses: write    
     secrets:
       AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions linter workflows to explicitly configure token permissions for checks and statuses.
  * Streamlined Super Linter workflow by removing redundant job-level permissions.

* **Documentation**
  * Added example permissions block to the README for the Super Linter workflow.
  * Updated CHANGELOG: re-labeled #58 entry and added #59 noting permissions updates to linter workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->