### PR TITLE
fix(docs): Update `README.md` to include supported databases with Docker images and health check commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug #58: Better naming workflow `reusable-linter.yml` to `super-linter.yml` (@terabytesoftw)
 - Bug #59: Add permissions to `linter` job in `linter.yml` and `super-linter.yml` (@terabytesoftw)
 - Bug #60: Update `OS` description to specify `JSON` array format for runner inputs (@terabytesoftw)
+- Bug #61: Update `README.md` to include supported databases with Docker images and health check commands (@terabytesoftw)
 
 ## v1.0.4 August 30, 2025
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,15 @@ jobs:
 <!-- prettier-ignore-end -->
 <!-- editorconfig-checker-enable -->
 
+**Supported Databases:**
+
+| Database   | Docker Image                     | Default Port | Health Check Command     |
+| ---------- | -------------------------------- | ------------ | ------------------------ |
+| MySQL      | `mysql`                          | 3306         | `mysqladmin ping`        |
+| PostgreSQL | `postgres`                       | 5432         | `pg_isready`             |
+| SQL Server | `mcr.microsoft.com/mssql/server` | 1433         | `sqlcmd -Q "SELECT 1"`   |
+| Oracle     | `gvenzl/oracle-xe`               | 1521         | `sqlplus -S / as sysdba` |
+
 ### PHPStan Static Analysis
 
 <!-- editorconfig-checker-disable -->
@@ -324,15 +333,6 @@ jobs:
 <!-- editorconfig-checker-enable -->
 
 > **Note**: YAML files should use 2-space indentation. This example shows correct YAML syntax - copy it to your `.github/workflows/*.yml` files as-is.
-
-**Supported Databases:**
-
-| Database   | Docker Image                     | Default Port | Health Check Command     |
-| ---------- | -------------------------------- | ------------ | ------------------------ |
-| MySQL      | `mysql`                          | 3306         | `mysqladmin ping`        |
-| PostgreSQL | `postgres`                       | 5432         | `pg_isready`             |
-| SQL Server | `mcr.microsoft.com/mssql/server` | 1433         | `sqlcmd -Q "SELECT 1"`   |
-| Oracle     | `gvenzl/oracle-xe`               | 1521         | `sqlplus -S / as sysdba` |
 
 ## Package information
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Added a consolidated “Supported Databases” section near the top, listing Docker images, default ports, and health check commands for MySQL, PostgreSQL, SQL Server, and Oracle.
  * Removed a duplicate databases section from later in the README for clarity.
  * Updated CHANGELOG with an entry documenting this documentation-only fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->