### PR TITLE
fix(workflows): Change `AUTH_TOKEN` requirement to `false` in multiple workflow files.

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -68,7 +68,7 @@ on:
     secrets:
       AUTH_TOKEN:
         description: GitHub token.
-        required: true
+        required: false
       CODECOV_TOKEN:
         description: Codecov token.
         required: false

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -58,7 +58,7 @@ on:
     secrets:
       AUTH_TOKEN:
         description: GitHub token.
-        required: true
+        required: false
 
 jobs:
   composer-require-checker:

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -58,7 +58,7 @@ on:
     secrets:
       AUTH_TOKEN:
         description: GitHub token.
-        required: true
+        required: false
 
 jobs:
   ecs:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -68,7 +68,7 @@ on:
     secrets:
       AUTH_TOKEN:
         description: GitHub token.
-        required: true
+        required: false
 
 jobs:
   phpstan:

--- a/.github/workflows/phpunit-database.yml
+++ b/.github/workflows/phpunit-database.yml
@@ -139,7 +139,7 @@ on:
     secrets:
       AUTH_TOKEN:
         description: GitHub token.
-        required: true
+        required: false
       CODECOV_TOKEN:
         description: Codecov token.
         required: false

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -103,7 +103,7 @@ on:
     secrets:
       AUTH_TOKEN:
         description: GitHub token.
-        required: true
+        required: false
       CODECOV_TOKEN:
         description: Codecov token.
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v.2.0.1 Under development
 
 - Bug #62: Improve command building in `phpunit` and `infection` action for better readability and maintainability (@terabytesoftw)
+- Bug #63: Change `AUTH_TOKEN` requirement to `false` in multiple workflow files (@terabytesoftw)
 
 ## v2.0.0 September 13, 2025
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated continuous integration workflows to make the authentication token optional, easing contributor setup and allowing runs without a token when not needed. No impact on app features or behavior.

- Documentation
  - Updated the changelog to note the change in workflow token requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->