### PR TITLE
refactor(linter): Add validation input options for `super-linter.yml`actions.

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -59,6 +59,21 @@ on:
         default: false
         required: false
         type: boolean
+      validate_php_phpcs:
+        description: Enable PHP PHPCS validation.
+        default: false
+        required: false
+        type: boolean
+      validate_php_phpstan:
+        description: Enable PHP PHPStan validation.
+        default: false
+        required: false
+        type: boolean
+      validate_php_psalm:
+        description: Enable PHP Psalm validation.
+        default: false
+        required: false
+        type: boolean
       validate_trivy:
         description: Enable Trivy validation.
         default: false
@@ -99,4 +114,7 @@ jobs:
           VALIDATE_JSCPD: ${{ inputs.validate_jscpd }}
           VALIDATE_PHP: ${{ inputs.validate_php }}
           VALIDATE_PHP_BUILTIN: ${{ inputs.validate_php_builtin }}
+          VALIDATE_PHP_PHPCS: ${{ inputs.validate_php_phpcs }}
+          VALIDATE_PHP_PHPSTAN: ${{ inputs.validate_php_phpstan }}
+          VALIDATE_PHP_PSALM: ${{ inputs.validate_php_psalm }}
           VALIDATE_TRIVY: ${{ inputs.validate_trivy }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -24,6 +24,41 @@ on:
         default: '["ubuntu-latest"]'
         required: false
         type: string
+      validate_checkov:
+        description: Enable Checkov validation.
+        default: false
+        required: false
+        type: boolean
+      validate_env:
+        description: Enable ENV file validation.
+        default: false
+        required: false
+        type: boolean
+      validate_github_actions_zizmor:
+        description: Enable GitHub Actions Zizmor validation.
+        default: false
+        required: false
+        type: boolean
+      validate_git_merge_conflict_markers:
+        description: Enable Git merge conflict markers validation.
+        default: false
+        required: false
+        type: boolean
+      validate_jscpd:
+        description: Enable JSCPD validation.
+        default: false
+        required: false
+        type: boolean
+      validate_php:
+        description: Enable PHP validation.
+        default: false
+        required: false
+        type: boolean
+      validate_trivy:
+        description: Enable Trivy validation.
+        default: false
+        required: false
+        type: boolean
 
     secrets:
       AUTH_TOKEN:
@@ -50,11 +85,12 @@ jobs:
         uses: super-linter/super-linter/slim@v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
-          VALIDATE_CHECKOV: ${{ env.VALIDATE_CHECKOV || 'false' }}
-          VALIDATE_ENV: ${{ env.VALIDATE_ENV || 'false' }}
-          VALIDATE_GIT_MERGE_CONFLICT_MARKERS: >-
-            ${{ env.VALIDATE_GIT_MERGE_CONFLICT_MARKERS || 'false' }}
+          VALIDATE_CHECKOV: ${{ inputs.validate_checkov }}
+          VALIDATE_ENV: ${{ inputs.validate_env }}
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: >-
-            ${{ env.VALIDATE_GITHUB_ACTIONS_ZIZMOR || 'false' }}
-          VALIDATE_JSCPD: ${{ env.VALIDATE_JSCPD || 'false' }}
-          VALIDATE_TRIVY: ${{ env.VALIDATE_TRIVY || 'false' }}
+            ${{ inputs.validate_github_actions_zizmor }}
+          VALIDATE_GIT_MERGE_CONFLICT_MARKERS: >-
+            ${{ inputs.validate_git_merge_conflict_markers }}
+          VALIDATE_JSCPD: ${{ inputs.validate_jscpd }}
+          VALIDATE_PHP: ${{ inputs.validate_php }}
+          VALIDATE_TRIVY: ${{ inputs.validate_trivy }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -54,6 +54,11 @@ on:
         default: false
         required: false
         type: boolean
+      validate_php_builtin:
+        description: Enable PHP Builtin validation.
+        default: false
+        required: false
+        type: boolean
       validate_trivy:
         description: Enable Trivy validation.
         default: false
@@ -93,4 +98,5 @@ jobs:
             ${{ inputs.validate_git_merge_conflict_markers }}
           VALIDATE_JSCPD: ${{ inputs.validate_jscpd }}
           VALIDATE_PHP: ${{ inputs.validate_php }}
+          VALIDATE_PHP_BUILTIN: ${{ inputs.validate_php_builtin }}
           VALIDATE_TRIVY: ${{ inputs.validate_trivy }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.0.2 Under development
 
+- Bug #64: Add validation input options for `super-linter.yml` actions (@terabytesoftw)
+
 ## v2.0.1 September 25, 2025
 
 - Bug #62: Improve command building in `phpunit` and `infection` action for better readability and maintainability (@terabytesoftw)


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow inputs to toggle additional validations: Checkov, Env, GitHub Actions Zizmor, Merge Conflict Markers, JSCPD, PHP (Builtin, PHPCS, PHPStan, Psalm) and Trivy — all default to off.
  * Exposed these toggles on the public workflow surface so callers can control which checks run.

* **Chores**
  * Switched the lint workflow to use inputs instead of environment variables and forward all toggles into the linter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->