### PR TITLE
fix(workflows): Add `ignore-platform-reqs` input to multiple workflow files.

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -54,6 +54,11 @@ on:
         default:
         required: false
         type: string
+      ignore-platform-reqs:
+        description: Whether to add --ignore-platform-reqs to composer command.
+        default: false
+        required: false
+        type: boolean
       os:
         description: OS runner as a JSON array string '["ubuntu-latest"]'.
         default: '["ubuntu-latest","windows-2022"]'
@@ -120,6 +125,7 @@ jobs:
           composer-version: ${{ inputs.composer-version }}
           coverage-driver: ${{ inputs.coverage-driver }}
           extensions: ${{ inputs.extensions }}
+          ignore-platform-reqs: ${{ inputs.ignore-platform-reqs }}
           ini-values: ${{ inputs.php-ini-values }}
           php-version: ${{ matrix.php-version }}
           tools: ${{ inputs.tools }}

--- a/.github/workflows/composer-require-checker.yml
+++ b/.github/workflows/composer-require-checker.yml
@@ -44,6 +44,11 @@ on:
         default:
         required: false
         type: string
+      ignore-platform-reqs:
+        description: Whether to add --ignore-platform-reqs to composer command.
+        default: false
+        required: false
+        type: boolean
       os:
         description: OS runner as a JSON array string '["ubuntu-latest"]'.
         default: '["ubuntu-latest"]'
@@ -103,6 +108,7 @@ jobs:
           composer-version: ${{ inputs.composer-version }}
           coverage-driver: none
           extensions: ${{ inputs.extensions }}
+          ignore-platform-reqs: ${{ inputs.ignore-platform-reqs }}
           ini-values: ${{ inputs.php-ini-values }}
           php-version: ${{ matrix.php-version }}
           tools: ${{ inputs.tools }}

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -44,6 +44,7 @@ on:
         default:
         required: false
         type: string
+
       os:
         description: OS runner as a JSON array string '["ubuntu-latest"]'.
         default: '["ubuntu-latest"]'

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -74,6 +74,11 @@ on:
         default:
         required: false
         type: string
+      ignore-platform-reqs:
+        description: Whether to add --ignore-platform-reqs to composer command.
+        default: false
+        required: false
+        type: boolean
       os:
         description: OS runner as a JSON array string '["ubuntu-latest"]'.
         default: '["ubuntu-latest"]'
@@ -144,6 +149,7 @@ jobs:
           composer-version: ${{ inputs.composer-version }}
           coverage-driver: ${{ inputs.coverage-driver }}
           extensions: ${{ inputs.extensions }}
+          ignore-platform-reqs: ${{ inputs.ignore-platform-reqs }}
           ini-values: ${{ inputs.php-ini-values }}
           php-version: ${{ matrix.php-version }}
           tools: ${{ inputs.tools }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -54,6 +54,11 @@ on:
         default: ""
         required: false
         type: string
+      ignore-platform-reqs:
+        description: Whether to add --ignore-platform-reqs to composer command.
+        default: false
+        required: false
+        type: boolean
       os:
         description: OS runner as a JSON array string '["ubuntu-latest"]'.
         default: '["ubuntu-latest"]'
@@ -113,6 +118,7 @@ jobs:
           composer-version: ${{ inputs.composer-version }}
           coverage-driver: none
           extensions: ${{ inputs.extensions }}
+          ignore-platform-reqs: ${{ inputs.ignore-platform-reqs }}
           ini-values: ${{ inputs.php-ini-values }}
           php-version: ${{ matrix.php-version }}
           tools: ${{ inputs.tools }}

--- a/.github/workflows/phpunit-database.yml
+++ b/.github/workflows/phpunit-database.yml
@@ -90,6 +90,11 @@ on:
         default:
         required: false
         type: string
+      ignore-platform-reqs:
+        description: Whether to add --ignore-platform-reqs to composer command.
+        default: false
+        required: false
+        type: boolean
       os:
         description: OS runner as a JSON array string '["ubuntu-latest"]'.
         default: '["ubuntu-latest","windows-2022"]'
@@ -205,6 +210,7 @@ jobs:
           composer-version: ${{ inputs.composer-version }}
           coverage-driver: ${{ inputs.coverage-driver }}
           extensions: ${{ inputs.extensions }}
+          ignore-platform-reqs: ${{ inputs.ignore-platform-reqs }}
           ini-values: ${{ inputs.php-ini-values }}
           php-version: ${{ matrix.php-version }}
           tools: ${{ inputs.tools }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -59,6 +59,11 @@ on:
         default:
         required: false
         type: string
+      ignore-platform-reqs:
+        description: Whether to add --ignore-platform-reqs to composer command.
+        default: false
+        required: false
+        type: boolean
       os:
         description: OS runner as a JSON array string '["ubuntu-latest"]'.
         default: '["ubuntu-latest","windows-2022"]'
@@ -151,6 +156,7 @@ jobs:
           composer-version: ${{ inputs.composer-version }}
           coverage-driver: ${{ inputs.coverage-driver }}
           extensions: ${{ inputs.extensions }}
+          ignore-platform-reqs: ${{ inputs.ignore-platform-reqs }}
           ini-values: ${{ inputs.php-ini-values }}
           php-version: ${{ matrix.php-version }}
           tools: ${{ inputs.tools }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.0.5 Under development
 
+- Bug #68: Add `ignore-platform-reqs` input to multiple workflow files (@terabytesoftw)
+
 ## v2.0.4 September 29, 2025
 
 - Bug #66: Fix `linter.yml` workflow to add permissions for checks, contents, and statuses (@terabytesoftw)


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable option to ignore Composer platform requirements across CI workflows, improving flexibility when running checks and tests.
  - Introduced a selectable operating system input for the ECS workflow to broaden environment coverage.
- Documentation
  - Updated the changelog to note the new workflow inputs and related improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->